### PR TITLE
Fix inference of `arr_idx`

### DIFF
--- a/test/interleaved.jl
+++ b/test/interleaved.jl
@@ -4,14 +4,7 @@ A1 = rand(3,3,3,5)
 A2 = rand(3,3,3,5)
 ss = InterleavedImage(A1,A2,4)
 
-#type inference bug?
-##code_warntype shows that the below is inferrable...
-#_A1 = rand(3,3,3)
-#_A2 = rand(3,3,3)
-#_ss = InterleavedImage(_A1,_A2,3)
-#@code_warntype(_ss[1,3,2])
-##yet the below is not inferrable...
-#@code_warntype(ss[1,3,2,3])
+@test @inferred(ss[1,3,2,3]) == A1[1,3,2,2]
 
 @test all(ss[:,:,:,1].==A1[:,:,:,1])
 @test all(ss[:,:,:,2].==A2[:,:,:,1])


### PR DESCRIPTION
To avoid the possibility of inference taking "forever," modern Julia tries to prove that inference will converge---when it can't prove that, it aborts early, leaving your inference problem unfinished (and therefore with an unsatisfying result). It's easy to prove convergence if argument sizes shrink (e.g., the `Base.tail` pattern), but often not possible if arguments grow. Hence it's better to avoid the grow-a-tuple pattern.

This might look like it makes two passes through the tuples, but since all these computations happen at compile time it doesn't have any impact on runtime.